### PR TITLE
Commit offline "additions" to store

### DIFF
--- a/src/module/actions.ts
+++ b/src/module/actions.ts
@@ -451,7 +451,7 @@ export default function (Firebase: any): AnyObject {
           querySnapshot.docChanges().forEach(change => {
             const changeType = change.type
             // Don't do anything for local modifications & removals
-            if (source === 'local') return resolve()
+            if (source === 'local' && changeType !== 'added') return resolve()
             const id = change.doc.id
             const doc = getters.cleanUpRetrievedDoc(change.doc.data(), id)
             dispatch('applyHooksAndUpdateState', {change: changeType, id, doc})


### PR DESCRIPTION
I was running into an issue where, when reloading my app in offline mode (I have service workers to cache all my app code), any collections that had pending updates would not populate into Vuex. Even though Firestore was aware of the documents even after the reload. I spent some time stepping through the code and this was the solution I came up with. I didn't run into any issues when testing and  none of the tests are failing.