### PR TITLE
Updated to match main docs

### DIFF
--- a/docs/extra-features.md
+++ b/docs/extra-features.md
@@ -291,11 +291,11 @@ For this shortcut usage, import the npm module 'vuex-easy-access' when you initi
 Also add `{vuexEasyFirestore: true}` in the options when you initialise 'vuex-easy-access' like so:
 
 ```js
-import vuexEasyAccess from 'vuex-easy-access'
-const easyAccess = vuexEasyAccess({vuexEasyFirestore: true})
+import createEasyAccess from "vuex-easy-access";
+const easyAccess = createEasyAccess({ vuexEasyFirestore: true });
 
 const store = {
-  plugins: [easyFirestoreModules, easyAccess]
+  plugins: [easyFirestore, easyAccess]
 }
 ```
 


### PR DESCRIPTION
I changed the initialisation to match the docs for Vuex Easy Access https://mesqueeb.github.io/vuex-easy-access/setup.html#installation
and for EasyFirestore https://mesqueeb.github.io/vuex-easy-firestore/setup.html#setup

I don't know if this is correct!  But if it's a different setup when they are used together perhaps you should add a line explaining that?