### PR TITLE
Add missing forward slash in import path

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -57,7 +57,7 @@ import VuexEasyFirestore from 'vuex-easy-firestore'
 Vue.use(Vuex)
 
 // import from step 1
-import { Firebase, initFirebase } from '~config/firebase.js'
+import { Firebase, initFirebase } from '~/config/firebase.js'
 // import from step 3 (below)
 import myModule from './modules/myModule.js'
 


### PR DESCRIPTION
I just noticed that you were missing a forward slash in this import statement when copying your example code.

Thanks a bunch for module 👌