### PR TITLE
Always include metadata changes in `onSnapshot`

### DIFF
--- a/docs/query-data.md
+++ b/docs/query-data.md
@@ -62,10 +62,10 @@ dispatch('moduleName/openDBChannel')
   })
 ```
 
-Sometimes the promise returned by the action might not be enough for you, because you need to know when the module has been populated with fresh data, not cached data. In that case, you need to pass an option when calling the action, which in turn will provide you with an additional promise. This, however, will also trigger your server hook listeners more frequently. Read [Firestore's documentation](https://firebase.google.com/docs/firestore/query-data/listen#events-metadata-changes) to know more about this.
+Sometimes the promise returned by the action might not be enough for you, because you need to know when the module has been populated with fresh data, not cached data. In that case, bind on the `refreshed` promise which is also provided.
 
 ```js
-dispatch('moduleName/openDBChannel', {includeMetadataChanges: true})
+dispatch('moduleName/openDBChannel')
   .then(({refreshed, streaming}) => {
   
     refreshed


### PR DESCRIPTION
I removed the `includeMetadataChanges` option of `openDBChannel` and enabled it in all cases.
As usual, this is backwards compatible.
Now, the `refreshed` promise is always available all the time, and we filter the changes for the user, it's simpler at all levels.
We'll have to watch metadata changes anyway when we implement 1-way sync, so I thought why not implement them now.
~~To prevent unnecessary calls to the hook callbacks, I added a function that checks if the data is new compared to the last snapshot we got.
I was initially worried that it could have a performance overhead because of a deep equal comparison could have been needed, but actually a basic, fast comparison of JSONs is totally fine, because Firestore has no reason to change the structure of data anyway.
As a bonus, it will even prevent some unnecessary hook calls in some case, like when you open several channels, or when the document was written to without actually changing the data itself.~~