### PR TITLE
Retry IDB errors from batch.commit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vuex-easy-firestore",
-  "version": "1.35.7",
+  "version": "1.35.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1972,16 +1972,16 @@
       }
     },
     "@firebase/analytics": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.3.2.tgz",
-      "integrity": "sha512-z4mYytlmnNipXQrGB6bN0tzWa9GzCtK0M2HD86C9OFYpwBeDQGc3UQPAM6kbfkv50Mnl4vlS5Ta2qEw/CvWwug==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.3.3.tgz",
+      "integrity": "sha512-Mj4lufHCnDqI2e8jAFqWmo9r2ejBJiGbI0MUvoiKVMxQm0kddQxUwmxfE6ozOAZ2HjB6OZ0iiAO+XU+0w/BnlA==",
       "dev": true,
       "requires": {
         "@firebase/analytics-types": "0.3.0",
-        "@firebase/component": "0.1.9",
-        "@firebase/installations": "0.4.7",
-        "@firebase/logger": "0.2.1",
-        "@firebase/util": "0.2.44",
+        "@firebase/component": "0.1.10",
+        "@firebase/installations": "0.4.8",
+        "@firebase/logger": "0.2.2",
+        "@firebase/util": "0.2.45",
         "tslib": "1.11.1"
       },
       "dependencies": {
@@ -2000,15 +2000,15 @@
       "dev": true
     },
     "@firebase/app": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.1.tgz",
-      "integrity": "sha512-KSzSFQfiJgxi+7Ff/EZQcdvCnqKj2db9xa7I8z1UoRIRez9e0Q6+GpW3mrSVmmSCrBbKYsOO/SJh5NaFot0evg==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.2.tgz",
+      "integrity": "sha512-rAxc90+82GAPpUxS02EO0dys4+TeQ6XjFjCwQz/OVptGeLgxN9ZoXYAf/bxyeYOdLxJW0kbEKE/0xXaJDt5gsg==",
       "dev": true,
       "requires": {
         "@firebase/app-types": "0.6.0",
-        "@firebase/component": "0.1.9",
-        "@firebase/logger": "0.2.1",
-        "@firebase/util": "0.2.44",
+        "@firebase/component": "0.1.10",
+        "@firebase/logger": "0.2.2",
+        "@firebase/util": "0.2.45",
         "dom-storage": "2.1.0",
         "tslib": "1.11.1",
         "xmlhttprequest": "1.8.0"
@@ -2029,9 +2029,9 @@
       "dev": true
     },
     "@firebase/auth": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.14.2.tgz",
-      "integrity": "sha512-5HaEGne2JbcVvzK9FeOEGi8NNQwq00thmL88uduqI8LTXHSOWaC8Y4El9DesVu6aFEOXELpf7W4I34CG9WwjlA==",
+      "version": "0.14.4",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.14.4.tgz",
+      "integrity": "sha512-cjYdSZQZ73jiI8De8Vw4L4LooXanc7HaYu4pEbq81Aag8fNy3oitfi0qTcrGLB7a/VLEAt1RtWo+lWotwCU2Ow==",
       "dev": true,
       "requires": {
         "@firebase/auth-types": "0.10.0"
@@ -2050,12 +2050,12 @@
       "dev": true
     },
     "@firebase/component": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.9.tgz",
-      "integrity": "sha512-i58GsVpxBGnKn1rx2RCAH0rk1Ldp6WterfBNDHyxmuyRO6BaZAgvxrZ3Ku1/lqiI7XMbmmRpP3emmwrStbFt9Q==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.10.tgz",
+      "integrity": "sha512-Iy1+f8wp6mROz19oxWUd31NxMlGxtW1IInGHITnVa6eZtXOg0lxcbgYeLp9W3PKzvvNfshHU0obDkcMY97zRAw==",
       "dev": true,
       "requires": {
-        "@firebase/util": "0.2.44",
+        "@firebase/util": "0.2.45",
         "tslib": "1.11.1"
       },
       "dependencies": {
@@ -2068,16 +2068,16 @@
       }
     },
     "@firebase/database": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.6.0.tgz",
-      "integrity": "sha512-b1wt4BpzFOXxAaUtkFqfoeZzmZIQ3sLiznqOYaAROnK2JMxpFF41Nh9wZ2tCze6rOkpN+3Kx33hsPCsrQcn0WQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.6.1.tgz",
+      "integrity": "sha512-7XqUbj3nK2vEdFjGOXBfKISmpLrM0caIwwfDPxhn6i7X/g6AIH+D1limH+Jit4QeKMh/IJZDNqO7P+Fz+e8q1Q==",
       "dev": true,
       "requires": {
         "@firebase/auth-interop-types": "0.1.4",
-        "@firebase/component": "0.1.9",
+        "@firebase/component": "0.1.10",
         "@firebase/database-types": "0.5.0",
-        "@firebase/logger": "0.2.1",
-        "@firebase/util": "0.2.44",
+        "@firebase/logger": "0.2.2",
+        "@firebase/util": "0.2.45",
         "faye-websocket": "0.11.3",
         "tslib": "1.11.1"
       },
@@ -2100,17 +2100,17 @@
       }
     },
     "@firebase/firestore": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-1.14.0.tgz",
-      "integrity": "sha512-JpwP6LWtNRjCtRbRvzhdtJ1tHL6r0MjCvmMr2Nv7bKmcjqoN8FiP+fZ9KkiZiqsSUhNsFFajyvx9n7R6vC+d2w==",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-1.14.2.tgz",
+      "integrity": "sha512-gUTQHiR1LN/g+iHfPZS+GJgDHK866xtAXcodSAOU4dt7k4B0oXllwuQmhjwQP0Gh7Lc/m+cK7dw/bmoHI6oWqQ==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.9",
+        "@firebase/component": "0.1.10",
         "@firebase/firestore-types": "1.10.1",
-        "@firebase/logger": "0.2.1",
-        "@firebase/util": "0.2.44",
-        "@firebase/webchannel-wrapper": "0.2.38",
-        "@grpc/grpc-js": "0.7.5",
+        "@firebase/logger": "0.2.2",
+        "@firebase/util": "0.2.45",
+        "@firebase/webchannel-wrapper": "0.2.39",
+        "@grpc/grpc-js": "0.8.1",
         "@grpc/proto-loader": "^0.5.0",
         "tslib": "1.11.1"
       },
@@ -2130,12 +2130,12 @@
       "dev": true
     },
     "@firebase/functions": {
-      "version": "0.4.40",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.4.40.tgz",
-      "integrity": "sha512-Yd0P+/xLt2Lc7AJpi1zff6xjVcJXpT7coTCBjb+58RQhECkoEh1ESx46VzoUGy+4ldoh/ZFFU7p0d/lG/+wDvg==",
+      "version": "0.4.42",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.4.42.tgz",
+      "integrity": "sha512-7L2l0NvWCL1z2vWqvxE7srQ64XCIzgMTIM2uANPT1yh+bMcZPxl3SuP4LoDhXbfmLtpzGKTygsxP4WKt5z7ctg==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.9",
+        "@firebase/component": "0.1.10",
         "@firebase/functions-types": "0.3.16",
         "@firebase/messaging-types": "0.4.4",
         "isomorphic-fetch": "2.2.1",
@@ -2157,14 +2157,14 @@
       "dev": true
     },
     "@firebase/installations": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.7.tgz",
-      "integrity": "sha512-Fz9B/H58xfkAnDGVTW1V/73Jd5LAN9o5dpz1K3+u2W+zp0iU6HoRTwm9Bgk+aV6/0FYjqmtYEDjK8T0OYPoIQA==",
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.8.tgz",
+      "integrity": "sha512-J3tyKCdZ07LR0Bw3rs4CIsWia5exGt77fdbvqnhYa6K8YfIUPFLzsGRvlFJkoIhOMXfujfnC3O/DakROOgOltg==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.9",
+        "@firebase/component": "0.1.10",
         "@firebase/installations-types": "0.3.3",
-        "@firebase/util": "0.2.44",
+        "@firebase/util": "0.2.45",
         "idb": "3.0.2",
         "tslib": "1.11.1"
       },
@@ -2184,21 +2184,21 @@
       "dev": true
     },
     "@firebase/logger": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.1.tgz",
-      "integrity": "sha512-H4nttTqUzEw3TA/JYl8ma6oMSNKHcdpEWV2L2qA+ZEcpM2OLAzagi//DrYBFR5xpPb17IGagpzSxFgx937Sq/A==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.2.tgz",
+      "integrity": "sha512-MbEy17Ha1w/DlLtvxG89ScQ+0+yoElGKJ1nUCQHHLjeMNsRwd2wnUPOVCsZvtBzQp8Z0GaFmD4a2iG2v91lEbA==",
       "dev": true
     },
     "@firebase/messaging": {
-      "version": "0.6.12",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.6.12.tgz",
-      "integrity": "sha512-U5piZd/0JFI4/2ZqTiIGYPcQBeTit6fTUbozGn2RSKcQw6WuNb9QJDbTZCzo1BzrHf1zoIqyakggL2AvIq48vA==",
+      "version": "0.6.14",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.6.14.tgz",
+      "integrity": "sha512-OuXbSGrNxhWYuHTGAjM55uTUMwsxd+S+fxj6OOyY26ezBOGj0tdPAHnAq+9wFwaItgAx8RUMjJF98Cc08PQqPA==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.9",
-        "@firebase/installations": "0.4.7",
+        "@firebase/component": "0.1.10",
+        "@firebase/installations": "0.4.8",
         "@firebase/messaging-types": "0.4.4",
-        "@firebase/util": "0.2.44",
+        "@firebase/util": "0.2.45",
         "idb": "3.0.2",
         "tslib": "1.11.1"
       },
@@ -2218,16 +2218,16 @@
       "dev": true
     },
     "@firebase/performance": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.3.0.tgz",
-      "integrity": "sha512-206klc2wzajagbHlR7T2GWvFHsfoRMMWLa2K3GIe6ikDGlPYa/F2byXYzv6e3mSOw6aKLSbTVcIaLBBourpOTA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.3.2.tgz",
+      "integrity": "sha512-awtqXas+Z0aud73pjvf1fAXMYe8Q+TSKNKnwyeMLqAWwHMwoywKGgksqGvOeg5hGQl5H7lzcnFHJ0HybMy1b9w==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.9",
-        "@firebase/installations": "0.4.7",
-        "@firebase/logger": "0.2.1",
+        "@firebase/component": "0.1.10",
+        "@firebase/installations": "0.4.8",
+        "@firebase/logger": "0.2.2",
         "@firebase/performance-types": "0.0.12",
-        "@firebase/util": "0.2.44",
+        "@firebase/util": "0.2.45",
         "tslib": "1.11.1"
       },
       "dependencies": {
@@ -2246,20 +2246,20 @@
       "dev": true
     },
     "@firebase/polyfill": {
-      "version": "0.3.33",
-      "resolved": "https://registry.npmjs.org/@firebase/polyfill/-/polyfill-0.3.33.tgz",
-      "integrity": "sha512-Arp9JViyD2i0K01NCCY0WZK5p16kQB/wddf44+Qboh+u3eIrFbVk0OO2IknjrkzIW392u73Ts7TkVxLPGPJF9g==",
+      "version": "0.3.34",
+      "resolved": "https://registry.npmjs.org/@firebase/polyfill/-/polyfill-0.3.34.tgz",
+      "integrity": "sha512-6EN02vwhX6cmyB4YswKhHkS3kMeNDxjCgf4vR3L9wYv+A5QVgAM85ifzf3mZT0tq3f2LfIsTsCIr/mlz2Swl1A==",
       "dev": true,
       "requires": {
-        "core-js": "3.6.4",
+        "core-js": "3.6.5",
         "promise-polyfill": "8.1.3",
         "whatwg-fetch": "2.0.4"
       },
       "dependencies": {
         "core-js": {
-          "version": "3.6.4",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
-          "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
+          "version": "3.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+          "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
           "dev": true
         },
         "whatwg-fetch": {
@@ -2271,16 +2271,16 @@
       }
     },
     "@firebase/remote-config": {
-      "version": "0.1.18",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.18.tgz",
-      "integrity": "sha512-ufbhnP3O6bRYs74jFIyYZ0dPsv/PsMSmGs669Os5SkEdfjEWX8hnhssfuZCg5VfJQiCrqoSQD/KfPGACmeBcbQ==",
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.19.tgz",
+      "integrity": "sha512-2n6bavDGO+cQsS3fs+yHthnkp5TKh8sqSD89dztt/b3/KKRb4C89r3apb6QIcQw/AlyToM+NyU6WIZyXfVAhqQ==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.9",
-        "@firebase/installations": "0.4.7",
-        "@firebase/logger": "0.2.1",
+        "@firebase/component": "0.1.10",
+        "@firebase/installations": "0.4.8",
+        "@firebase/logger": "0.2.2",
         "@firebase/remote-config-types": "0.1.8",
-        "@firebase/util": "0.2.44",
+        "@firebase/util": "0.2.45",
         "tslib": "1.11.1"
       },
       "dependencies": {
@@ -2299,14 +2299,14 @@
       "dev": true
     },
     "@firebase/storage": {
-      "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.3.31.tgz",
-      "integrity": "sha512-b5rwcMa89mFnKDlhFmGRC0QFpOgqGoNVn4klJDvSnpRGmwOcByQXoos8w1IWP0DW+EWhHcafy7DvUHFlr70onw==",
+      "version": "0.3.32",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.3.32.tgz",
+      "integrity": "sha512-mwWI03VbTd1jP7mmeNBv7mJ96i8GUX1fSxVept5aV2FQb2pAWTKXr7Gmxg06w642I0T1+qZTRVXs8G5m8vuTjg==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.9",
+        "@firebase/component": "0.1.10",
         "@firebase/storage-types": "0.3.11",
-        "@firebase/util": "0.2.44",
+        "@firebase/util": "0.2.45",
         "tslib": "1.11.1"
       },
       "dependencies": {
@@ -2325,9 +2325,9 @@
       "dev": true
     },
     "@firebase/util": {
-      "version": "0.2.44",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.44.tgz",
-      "integrity": "sha512-yWnFdeuz7P0QC4oC77JyPdAQ/rTGPDfhHcR5WsoMsKBBHTyqEhaKWL9HeRird+p3AL9M4++ep0FYFNd1UKU3Wg==",
+      "version": "0.2.45",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.45.tgz",
+      "integrity": "sha512-k3IqXaIgwlPg7m5lXmMUtkqA/p+LMFkFQIqBuDtdT0iyWB6kQDokyjw2Sgd3GoTybs6tWqUKFZupZpV6r73UHw==",
       "dev": true,
       "requires": {
         "tslib": "1.11.1"
@@ -2342,15 +2342,15 @@
       }
     },
     "@firebase/webchannel-wrapper": {
-      "version": "0.2.38",
-      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.2.38.tgz",
-      "integrity": "sha512-mp1XmAJsuqaSWm5WQYo7R0zfZWe9EmwMCxsxkKr+ubLOumyNy4NG5aV45hEpFTosQv4myXpiCiS4GFE9mNqLZQ==",
+      "version": "0.2.39",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.2.39.tgz",
+      "integrity": "sha512-V5oQjtYxHlEpWdQr68ZFo8T+3NVccrTieRy8RnzYIasCeptxOxwYUG0cAAKmalgrrrfRJdXup8h5ybi3XSW9Hw==",
       "dev": true
     },
     "@grpc/grpc-js": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-0.7.5.tgz",
-      "integrity": "sha512-hhWT+vHPtG4tn0zZJw4ndfv730pBPb+lhJfvQhc7ANBvqixtlNOaXm9VNI98wYF/em0PnrskXnOr8rHh96zjlg==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-0.8.1.tgz",
+      "integrity": "sha512-e8gSjRZnOUefsR3obOgxG9RtYW2Mw83hh7ogE2ByCdgRhoX0mdnJwBcZOami3E0l643KCTZvORFwfSEi48KFIQ==",
       "dev": true,
       "requires": {
         "semver": "^6.2.0"
@@ -8487,25 +8487,25 @@
       }
     },
     "firebase": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-7.14.0.tgz",
-      "integrity": "sha512-4QjP8WxVwVh6lvP8I96Wg11coJQ8si093xxUmafdOL7hWzG8u80EdlJOClK9zG8R37OjJRNsmXdslqFiJoGK5g==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-7.14.2.tgz",
+      "integrity": "sha512-B06h1sXe9ODcoHv0EjF4+CEcm2Gl+8eSL35iAYn8ZRi5Qzivlge312iSROLwGeIIO2QOA+2ap9D6/X52eLIAOg==",
       "dev": true,
       "requires": {
-        "@firebase/analytics": "0.3.2",
-        "@firebase/app": "0.6.1",
+        "@firebase/analytics": "0.3.3",
+        "@firebase/app": "0.6.2",
         "@firebase/app-types": "0.6.0",
-        "@firebase/auth": "0.14.2",
-        "@firebase/database": "0.6.0",
-        "@firebase/firestore": "1.14.0",
-        "@firebase/functions": "0.4.40",
-        "@firebase/installations": "0.4.7",
-        "@firebase/messaging": "0.6.12",
-        "@firebase/performance": "0.3.0",
-        "@firebase/polyfill": "0.3.33",
-        "@firebase/remote-config": "0.1.18",
-        "@firebase/storage": "0.3.31",
-        "@firebase/util": "0.2.44"
+        "@firebase/auth": "0.14.4",
+        "@firebase/database": "0.6.1",
+        "@firebase/firestore": "1.14.2",
+        "@firebase/functions": "0.4.42",
+        "@firebase/installations": "0.4.8",
+        "@firebase/messaging": "0.6.14",
+        "@firebase/performance": "0.3.2",
+        "@firebase/polyfill": "0.3.34",
+        "@firebase/remote-config": "0.1.19",
+        "@firebase/storage": "0.3.32",
+        "@firebase/util": "0.2.45"
       }
     },
     "flat-cache": {
@@ -12854,9 +12854,9 @@
       "dev": true
     },
     "protobufjs": {
-      "version": "6.8.9",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.9.tgz",
-      "integrity": "sha512-j2JlRdUeL/f4Z6x4aU4gj9I2LECglC+5qR2TrWb193Tla1qfdaNQTZ8I27Pt7K0Ajmvjjpft7O3KWTGciz4gpw==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.9.0.tgz",
+      "integrity": "sha512-LlGVfEWDXoI/STstRDdZZKb/qusoAWUnmLg9R8OLSO473mBLWHowx8clbX5/+mKDEI+v7GzjoK9tRPZMMcoTrg==",
       "dev": true,
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -12869,15 +12869,15 @@
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.0",
-        "@types/node": "^10.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": "^13.7.0",
         "long": "^4.0.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.19",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.19.tgz",
-          "integrity": "sha512-46/xThm3zvvc9t9/7M3AaLEqtOpqlYYYcCZbpYVAQHG20+oMZBkae/VMrn4BTi6AJ8cpack0mEXhGiKmDNbLrQ==",
+          "version": "13.13.4",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.4.tgz",
+          "integrity": "sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "eslint": "^5.16.0",
     "eslint-loader": "^2.2.1",
     "eslint-plugin-vue": "^5.2.3",
-    "firebase": "^7.14.0",
+    "firebase": "^7.14.2",
     "mock-cloud-firestore": "^0.9.3",
     "rollup": "^1.32.1",
     "rollup-plugin-node-resolve": "^4.2.4",

--- a/src/module/errors.ts
+++ b/src/module/errors.ts
@@ -61,6 +61,10 @@ const errorMessages = {
     Something went wrong while trying to synchronise data to Cloud Firestore.
     The data is kept in queue, so that it will try to sync again upon the next 'set' or 'patch' action.
   `,
+  'firestore-idb-unrecoverable': `
+    Firestore threw an IndexedDB Error when attempting to sync.
+    The retry operation was unsuccessful.
+  `,
 }
 
 /**


### PR DESCRIPTION
This addresses #321 

I am a little concerned that, due to the nature of the issue in IDB, an immediate single retry might not work in some cases.

The original issue in Firestore was caused when the IDB process was force-closed by the system (e.g. when a mobile device goes to sleep) and the transaction would be aborted. It might be possible that the retry happens before Firebase has re-established an IDB connection and is failed again.

To my knowledge, there's no easy way to test this. I think we can assume that if a commit is rejected with this error from Firebase, all subsequent commits will be rejected until it comes back online. Perhaps it might be sane to implement a retry with exponential back-off for this error.