### PR TITLE
cannot-find-options--patch

### DIFF
--- a/src/module/actions.ts
+++ b/src/module/actions.ts
@@ -338,7 +338,7 @@ export default function (firestoreConfig: FirestoreConfig): AnyObject {
         }
         // make fetch request
         fRef
-          .get(options)
+          .get(parameters.options)
           .then(querySnapshot => {
             const docs = querySnapshot.docs
             if (docs.length === 0) {
@@ -405,7 +405,7 @@ export default function (firestoreConfig: FirestoreConfig): AnyObject {
           )
         }
         return getters.dbRef
-          .get(options)
+          .get(parameters.options)
           .then(async _doc => {
             if (!_doc.exists) {
               // No initial doc found in docMode
@@ -475,9 +475,9 @@ export default function (firestoreConfig: FirestoreConfig): AnyObject {
         id,
         doc = {},
       }: {
-        change: 'added' | 'removed' | 'modified'
-        id: string
-        doc: AnyObject
+        change: 'added' | 'removed' | 'modified';
+        id: string;
+        doc: AnyObject;
       }
     ) {
       const store = this
@@ -701,7 +701,7 @@ export default function (firestoreConfig: FirestoreConfig): AnyObject {
         streamingStart()
         return initialPromise
       }
-      
+
       // const updateAllOpenTabsWithLocalPersistence = enablePersistence && synchronizeTabs
 
       /**


### PR DESCRIPTION
In reaction to the following error (@mesqueeb):

```
$ npm run rollup

> vuex-easy-firestore@1.37.0 rollup
> rollup -c build/rollup.js


src/index.ts → dist/index.cjs.js, dist/index.esm.js...
(!) Unresolved dependencies
https://rollupjs.org/guide/en/#warning-treating-module-as-external-dependency
firebase/compat/app (imported by src\index.ts, src\utils\incrementHelper.ts, src\utils\arrayHelpers.ts)
firebase/compat/firestore (imported by src\index.ts, src\utils\incrementHelper.ts, src\utils\arrayHelpers.ts)
firebase/compat/auth (imported by src\index.ts)
[!] (plugin rpt2) Error: .../vuex-easy-firestore/src/module/actions.ts(341,16): semantic error TS2552: Cannot find name 'options'. Did you mean 'Option'?
```